### PR TITLE
Gallery fix

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -78,12 +78,15 @@ bool Camera::getIsOn(){
 }
 
 /**
-* Sets doMeta to true, to enable metadata in frame structure.
+* Sets doMeta to true, to enable metadata in frame structure for the following frame.
 **/
 void Camera::captureMetadata(){
     doMeta = true;
 }
 
+/**
+* @param metadata updates exposure value saved in restored metadata map
+**/
 void Camera::updateSettings(std::map<std::string, std::string> metadata){
     exposureState = metadata[paramLabel];
 
@@ -102,6 +105,9 @@ void Camera::updateSettings(std::map<std::string, std::string> metadata){
     setExposure(metaThreshold);   
 }
 
+/**
+* Sets the note value which is saved in metadata and shown under images in the gallery preview.
+**/
 void Camera::setNote(std::string noteIn){
     note = noteIn;
     std::cout<<note<<std::endl;

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -110,5 +110,4 @@ void Camera::updateSettings(std::map<std::string, std::string> metadata){
 **/
 void Camera::setNote(std::string noteIn){
     note = noteIn;
-    std::cout<<note<<std::endl;
 }

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -102,7 +102,7 @@ void Camera::updateSettings(std::map<std::string, std::string> metadata){
         }
     }
     
-    setExposure(metaThreshold);   
+    //setExposure(metaThreshold);   //broken needs fixed 
 }
 
 /**

--- a/src/camera.h
+++ b/src/camera.h
@@ -19,9 +19,7 @@ public:
     Camera() = default;
     void start(int deviceID = 0, int apiID=0);
     void stop();
-    //void receiveFrame(frame newFrame);
     bool getIsOn();
-    //void registerCallback(imageProcessor*);
     void captureMetadata();
     void setExposure(int);
     std::string getParamLabel(){return paramLabel;};
@@ -40,7 +38,6 @@ private:
     bool isOn = false;
     std::string paramLabel = "exposure";
     std::string paramLabel2 = "note";
-    //imageProcessor* frameCb = nullptr;
     bool doMeta = false;
     std::string note = " ";
 

--- a/src/camera.h
+++ b/src/camera.h
@@ -42,7 +42,7 @@ private:
     std::string paramLabel2 = "note";
     //imageProcessor* frameCb = nullptr;
     bool doMeta = false;
-    std::string note = "";
+    std::string note = " ";
 
 };
 

--- a/src/camera.h
+++ b/src/camera.h
@@ -22,10 +22,19 @@ public:
     bool getIsOn();
     void captureMetadata();
     void setExposure(int);
-    std::string getParamLabel(){return paramLabel;};
     void updateSettings(std::map<std::string, std::string>);
-    void receiveFrame(frame newFrame){return;};
     void setNote(std::string);
+    
+    /**
+    * Not required for camera.
+    **/
+    std::string getParamLabel(){return paramLabel;};
+
+    /**
+    * Not required for camera.
+    **/
+    void receiveFrame(frame newFrame){return;};
+
 
     
 private:

--- a/src/frame.h
+++ b/src/frame.h
@@ -22,9 +22,6 @@ class frame{
         frame() = default;
         frame(cv::Mat matIn): image(matIn){}
 
-        //custom copy constructor replacement to allow test to pass,
-        // provide a pointer to existing frame
-        //and copy from there into a constructed second frame
         /**
         * Custom copy constructor.
         * Provide a pointer to an existing frame and copy from there into a constructed second frame.
@@ -61,12 +58,9 @@ class frame{
             "flatField",
             "exposure",
             "note"
-            //ADD MORE PARAMETERS HERE
+            //ADD MORE PARAMETERS HERE FOR NEW BLOCKS
         };
-
-
         std::string encodedString;
-
 };
 
 

--- a/src/gallery.cpp
+++ b/src/gallery.cpp
@@ -1,12 +1,7 @@
 #include "gallery.h"
-
-//TODO 
-//error checking if no pathname 
-
-//FUTURE todo:
-//configureable dir name and filename 
-//metadata saved? inside jpg or alongside comp7anion file to be viewed in cellUview gallery?
-
+/**
+* Initialises gallery file paths, directories, and indexing of the capture counter which is preserved between runs of cellUview
+**/
 Gallery::Gallery(){
 
 //---- find or create gallery directory----
@@ -21,7 +16,12 @@ Gallery::Gallery(){
     
 }
 
-int Gallery::initialiseDirectory(std::string path, std::string description){
+/**
+* Creates a directory if it does not already exist.
+* @param path The file path with which to initialise at
+* @param description String describing directory purpose to be used in terminal output
+**/
+void Gallery::initialiseDirectory(std::string path, std::string description){
         //if it doesn't exist
     if ((dir = opendir(path.c_str())) == NULL){
         //try to make the directory
@@ -31,7 +31,7 @@ int Gallery::initialiseDirectory(std::string path, std::string description){
             std::cout << description << " directory not found/created";
             //ADD. disable button if failed
             pathname = ""; 
-            return 1;
+            return;
         }
         else{//if gallery succesfully made
             std::cout << description << " directory created at " + path << std::endl;
@@ -41,31 +41,34 @@ int Gallery::initialiseDirectory(std::string path, std::string description){
         closedir(dir);
     }
     
-    return 0;
+    return;
 
     //updates index to find highest existing file with matching name to avoid overwriting
 }
 
-
-//add some error handling
+/**
+* Captures a frame and saves into the appropriate gallery directory
+* @param capFrame Frame structure containing metadata and cv::Mat of image
+* @param updateFlatField optional and if true captures into the flatfield directory, defaults to false and captures into main gallery directory
+* @param flatFieldCounter Adds index of the number of flat field counter as this will be called sequentially
+**/
 void Gallery::captureFrame(frame capFrame, bool updateFlatField, int flatFieldCounter){
-    if (pathname == ""){
+    if (pathname == ""){ //error checking, if pathname not set then skip
         return;
     }
     //add ability to set custom string before number
-    if (updateFlatField == true){
+    if (updateFlatField == true){ //flatfield capture
 
+        captureFname = pathname + "/.FlatFieldGallery/flatField" + std::to_string(flatFieldCounter) + ".jpg";
+        std::string flatFieldPath = captureFname;
 
-            captureFname = pathname + "/.FlatFieldGallery/flatField" + std::to_string(flatFieldCounter) + ".jpg";
-            std::string flatFieldPath = captureFname;
-
-            //save image
-            img = capFrame.image;
-            cv::imwrite(captureFname, img); 
+        //save image
+        img = capFrame.image;
+        cv::imwrite(captureFname, img); 
             
     }
-    else{
-        //build output name string
+    else{ //default capture
+        //build output name string 
         captureFname = pathname + imgName + std::to_string(captureImgCounter) +".jpg";
 
         //save image
@@ -73,18 +76,20 @@ void Gallery::captureFrame(frame capFrame, bool updateFlatField, int flatFieldCo
         cv::imwrite(captureFname, img); 
 
         captureImgCounter++;
-        
-
+        //add metadata into captured frame
         writeMetadata(capFrame, captureFname);
         
-        std::cout<<"Capturing"<<std::endl;
-        //debug
-        //std::cout << getMetadata() << std::endl;    
+        std::cout<<"Capturing"<<std::endl;   
 
     }   
     
 } 
 
+/**
+* Inserts metadata into saved capture using cpp_exiftool.
+* @param f Frame structure containing metadata and cv::Mat of image
+* @param captureFname Name of file to have metadata inserted into
+**/
 void Gallery::writeMetadata(frame f, std::string captureFname){
     MetadataToWrite = f.encodeMetadata();
     et->SetNewValue("XMP:Description", MetadataToWrite.c_str());
@@ -92,21 +97,20 @@ void Gallery::writeMetadata(frame f, std::string captureFname){
     int result = et->Complete();
     if (result<=0) std::cerr << "Error writing metadata" << std::endl;
 
-    //remove original image left over from exiftool
+    //remove original image left over from exiftool library
     std::string origCap = captureFname + "_original";
     std::remove(origCap.c_str());
 }
 
+/**
+* This reads back the saved metadata in a capture using cpp_exiftool
+* @param fname Frame structure containing metadata and cv::Mat of image
+* @returns restoredParams a map of the paramater and value as defined in frame.h 
+**/
 std::map<std::string, std::string> Gallery::getMetadata(std::string fname){
-    //Come back to here to pass in fname 
-    //for now just read back image capture from this run
-
-    if (fname == ""){
+    if (fname == ""){ //default to most recent capture
         fname = captureFname;
     }
-
-    //debug
-    // std::cout<<fname<<std::endl;
 
     receivedMetadata="";
     TagInfo *info = et->ImageInfo(fname.c_str());
@@ -129,7 +133,6 @@ std::map<std::string, std::string> Gallery::getMetadata(std::string fname){
                         rec.push_back(item);
                     }
                     restoredParams[rec[0]] = rec[1];
-                    //std::cout<< rec[0] + "::" + restoredParams[rec[0]]<< std::endl;
 
                     rec.clear();
                     
@@ -145,13 +148,16 @@ std::map<std::string, std::string> Gallery::getMetadata(std::string fname){
     }else{
         std::cout << "No metadata to read" << std::endl;
     }
-    //debug
-    //THIS DOESN'T BREAK
-    //std::cout<<restoredParams["edgeThreshold"]<<std::endl;
+
     return restoredParams;
 }
 
- 
+/**
+* Iterates through items in gallery directory to find the highest index of captureXYZ.jpg where XYZ is an integer counter of arbitrary length. 
+* this avoids captures being overwritten on following runs of cellUview
+* @param fname Frame structure containing metadata and cv::Mat of image
+* @returns restoredParams a map of the paramater and value as defined in frame.h 
+**/
 void Gallery::updateIndex(){
 //(re)open already existing/newly created directory 
     //to find if files with current name already exis.=t
@@ -182,12 +188,17 @@ void Gallery::updateIndex(){
         }
     closedir(dir);
     galleryDisplayIndex = captureImgCounter -4;
-    //debug
-    //std::cout << std::to_string(captureImgCounter) + " ALREADY FOUND" << std::endl;
+
     }  
 
 }
 
+/**
+ * Loads saved captures and notes to form list of pairs to provide to gui for display
+* Keeps track of gallery location, checking at extremes to not load non existent captures.
+* @param directionIsNext if true gets the next four saved captures, otherwise the previous.  
+* @returns stringCapPairs a list of pairs of strings (labels) and cv::Mat (image)
+**/
 std::list<std::pair<std::string, cv::Mat>>  Gallery::getCaptures(bool directionIsNext){
     //adjust increment of top left index to display
     if (directionIsNext == true){
@@ -195,8 +206,6 @@ std::list<std::pair<std::string, cv::Mat>>  Gallery::getCaptures(bool directionI
     }else{
         galleryDisplayIndex -= 4;
     }
-    //check not out of bounds, if so move to extremes
-    //std::cout<<galleryDisplayIndex<<std::endl;
 
     if (galleryDisplayIndex < 0){
         galleryDisplayIndex = 0;
@@ -215,7 +224,6 @@ std::list<std::pair<std::string, cv::Mat>>  Gallery::getCaptures(bool directionI
     galleryDisplayFname.clear();
     for (int i = 0; i<4; i++){
         panelIndex = galleryDisplayIndex + i;
-        //std::cout<<panelIndex<<std::endl;
         try{
 
             capturePathName = pathname + imgName + std::to_string(panelIndex) + ".jpg";
@@ -225,8 +233,6 @@ std::list<std::pair<std::string, cv::Mat>>  Gallery::getCaptures(bool directionI
             displayString = std::to_string(panelIndex) + ":   " + note; 
             galleryDisplayFname.push_back(capturePathName);
 
-            //std::cout<<note<<std::endl;;
-
 
         }catch(...){
             displayString = "";
@@ -234,7 +240,6 @@ std::list<std::pair<std::string, cv::Mat>>  Gallery::getCaptures(bool directionI
             captureMat = emptyMat;
         }
         stringCapPairs.push_back({displayString, captureMat});
-        //std::cout<<displayString<<std::endl;;
     
     }
     return stringCapPairs;
@@ -245,8 +250,6 @@ std::string Gallery::getGalleryDisplayFname(int pos){
 }
 
 bool Gallery::galleryAtEnd(){
-    //std::cout<<galleryDisplayIndex<<std::endl;
-    //std::cout<<captureImgCounter<<std::endl;
     return (galleryDisplayIndex + 5 == captureImgCounter);
 }
 

--- a/src/gallery.cpp
+++ b/src/gallery.cpp
@@ -151,21 +151,6 @@ std::map<std::string, std::string> Gallery::getMetadata(std::string fname){
     return restoredParams;
 }
 
-
-void Gallery::updateImgName(std::string newName){
-    if (newName.find("/") != std::string::npos) {
-        std::cout << "Error. Contains illegal / char" << std::endl;
-        //UPDATE TEXTBOX HERE TODO
-        //add check to see if names are the same, if they are then break. 
-    }else{//update name
-        imgName=newName;
-        updateIndex();
-    }
-    // if (newName.empty()){
-    //     imgName="Capture";
-    //     updateIndex();
-    // }
-}
  
 void Gallery::updateIndex(){
 //(re)open already existing/newly created directory 
@@ -211,7 +196,7 @@ std::list<std::pair<std::string, cv::Mat>>  Gallery::getCaptures(bool directionI
         galleryDisplayIndex -= 4;
     }
     //check not out of bounds, if so move to extremes
-    std::cout<<galleryDisplayIndex<<std::endl;
+    //std::cout<<galleryDisplayIndex<<std::endl;
 
     if (galleryDisplayIndex < 0){
         galleryDisplayIndex = 0;
@@ -230,20 +215,17 @@ std::list<std::pair<std::string, cv::Mat>>  Gallery::getCaptures(bool directionI
     galleryDisplayFname.clear();
     for (int i = 0; i<4; i++){
         panelIndex = galleryDisplayIndex + i;
-        std::cout<<panelIndex<<std::endl;
-        // if (panelIndex<0){ //error fixing
-        //     panelIndex =0;
-        // }
+        //std::cout<<panelIndex<<std::endl;
         try{
 
             capturePathName = pathname + imgName + std::to_string(panelIndex) + ".jpg";
             captureMat = cv::imread(capturePathName);
             metadataGalleryLabel= getMetadata(capturePathName);
             note = metadataGalleryLabel["note"];
-            displayString = std::to_string(panelIndex) + ":   " + note; //+METADATA
+            displayString = std::to_string(panelIndex) + ":   " + note; 
             galleryDisplayFname.push_back(capturePathName);
 
-            std::cout<<note<<std::endl;;
+            //std::cout<<note<<std::endl;;
 
 
         }catch(...){
@@ -263,10 +245,9 @@ std::string Gallery::getGalleryDisplayFname(int pos){
 }
 
 bool Gallery::galleryAtEnd(){
-    std::cout<<galleryDisplayIndex<<std::endl;
-    std::cout<<captureImgCounter<<std::endl;
+    //std::cout<<galleryDisplayIndex<<std::endl;
+    //std::cout<<captureImgCounter<<std::endl;
     return (galleryDisplayIndex + 5 == captureImgCounter);
 }
 
-//get rid of back slashes in names
 

--- a/src/gallery.h
+++ b/src/gallery.h
@@ -18,54 +18,51 @@
 #include <unordered_map>
 #include <list>
 
-class Gallery{
+class Gallery
+{
 
-    public:
-        Gallery();
-        void captureFrame(frame, bool flatfield=false, int flatFieldCounter = 0);
-        void updateImgName(std::string);
-        void updateIndex();
-        std::map<std::string, std::string> getMetadata(std::string = "");
+public:
+    Gallery();
+    void captureFrame(frame, bool flatfield = false, int flatFieldCounter = 0);
+    void updateImgName(std::string);
+    void updateIndex();
+    std::map<std::string, std::string> getMetadata(std::string = "");
 
-        std::string getPathname(){return pathname;}; //testing only
-        // std::string getFlatFieldPath(){return flatFieldPath;};
-        std::string getCaptureFname(){return captureFname;};//testing only
+    std::string getPathname() { return pathname; };         // testing only
+    std::string getCaptureFname() { return captureFname; }; // testing only
 
-        std::list<std::pair<std::string, cv::Mat>>  getCaptures(bool);
+    std::list<std::pair<std::string, cv::Mat>> getCaptures(bool);
 
-        bool galleryAtEnd();
-        std::string getGalleryDisplayFname(int);
+    bool galleryAtEnd();
+    std::string getGalleryDisplayFname(int);
 
-    private:
-        int initialiseDirectory(std::string, std::string);
-        void writeMetadata(frame, std::string);
+private:
+    void initialiseDirectory(std::string, std::string);
+    void writeMetadata(frame, std::string);
 
-        DIR *dir;
-        struct dirent *ent;
-        std::string pathname = "";
-        std::string flatFieldPath = "";
-        std::string imgName = "capture";
-        int captureImgCounter = 0;
-        std::string captureFname = "";
-        int index =0 ;
-        int lastHighestIndex = -1;
-        int indexLen = 1;
-        int galleryDisplayIndex = 0;
-        std::string existingCaptureFname; 
+    DIR *dir;
+    struct dirent *ent;
+    std::string pathname = "";
+    std::string flatFieldPath = "";
+    std::string imgName = "capture";
+    int captureImgCounter = 0;
+    std::string captureFname = "";
+    int index = 0;
+    int lastHighestIndex = -1;
+    int indexLen = 1;
+    int galleryDisplayIndex = 0;
+    std::string existingCaptureFname;
 
+    cv::Mat img;
 
-        cv::Mat img;
+    std::string tagName;
+    std::string receivedMetadata;
+    std::string MetadataToWrite;
 
-        std::string tagName;
-        std::string receivedMetadata;
-        std::string MetadataToWrite;
+    ExifTool *et = new ExifTool();
 
-        ExifTool *et = new ExifTool();
+    std::map<std::string, std::string> restoredParams;
 
-        std::map<std::string, std::string> restoredParams;
-
-        std::vector<std::string> galleryDisplayFname;
-
-
+    std::vector<std::string> galleryDisplayFname;
 };
-#endif //CELLUVIEW_GALLERY_H
+#endif // CELLUVIEW_GALLERY_H

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -338,15 +338,17 @@ void Gui::updateSettings(std::map<std::string, std::string> metadata){
         }
 
         else if(label == "exposure"){
-            try{
-                ui->exposureSlider->setValue(std::stoi(value));
-            }catch(...){
-                if (value == "OFF"){
-                    ui->exposureSlider->setValue(0);
-                }else{
-                std::cerr<<"Invalid metadata for contrast enhancement"<<std::endl;
-                }
-            }
+            ////broken fix this
+            // try{
+            //     ui->exposureSlider->setValue(std::stoi(value));
+            // }catch(...){
+            //     if (value == "OFF"){
+            //         ui->exposureSlider->setValue(0);
+            //     }else{
+            //     std::cerr<<"Invalid metadata for contrast enhancement"<<std::endl;
+            //     }
+            // } 
+            ;
         }
 
         else if(label == "erosion"){

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -374,9 +374,10 @@ void Gui::updateSettings(std::map<std::string, std::string> metadata){
 **/
 void Gui::updateGalleryView(bool directionIsNext){
     std::list<std::pair<std::string, cv::Mat>> loaded = this->gallery->getCaptures(directionIsNext);
-    std::vector<std::string> keys;
+    //std::vector<std::string> keys;
     std::list<std::pair<std::string, cv::Mat>>::const_iterator it;
     mats.clear();
+    keys.clear();
     for (it = loaded.begin(); it != loaded.end(); ++it){
         keys.push_back(it->first);
         mats.push_back(it->second);
@@ -466,54 +467,40 @@ void Gui::updateGalleryView(bool directionIsNext){
 * Displays a popup window showing a full-sized capture with a button option to restore settings from that capture.
 * @param position position within the four spaced as 0, 1 on top row and 2, 3 on the bottom.
 **/
-//function that see's that the button is pressed, return true, make batch index go to the end and show now image, 
 void Gui::showDialog(int position) {
     dialog.accept();
     if (position!=-1){
-    dialog.setWindowTitle("Restore Settings");
-
-    // // Load the image and create a pixmap
-    // std::string directoryStr = this->gallery->getPathname();
-    // QString directory = QString::fromStdString(directoryStr);
-    // QDir imageDir(directory);
-   
-    // imageFilters << "*.jpg";
-    // QStringList images = imageDir.entryList(imageFilters, QDir::Files | QDir::Readable);
-    // QSize labelSize = ui->galleryPos1->size();
-
-    // QImage image(directory + "/" + images[position]);
-    // QString imagName = images.at(position);
-    QString caption = galleryStrs[position];
-    //QImage image = galleryQImages[position];
-    ////vpassing wasn't working so trying
-    cv::Mat img = mats[position];
-    std::cout<<img.size()<<std::endl;
-    //cv::cvtColor(img, img, cv::COLOR_BGR2RGB);
-    QImage dialogImg = QImage((uchar *)img.data, img.cols, img.rows, img.step,
-                        QImage::Format_RGB888);
-    QLabel label;
-    label.setPixmap(QPixmap::fromImage(dialogImg));//.scaled(labelSize, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+        //dialog.setWindowTitle("Restore Settings");
+        std::string title = keys[position];
+        QString titleQ = QString::fromStdString(title);
+        dialog.setWindowTitle(titleQ);
+        QString caption = galleryStrs[position];
+        cv::Mat img = mats[position];
+        std::cout<<img.size()<<std::endl;
+        QImage dialogImg = QImage((uchar *)img.data, img.cols, img.rows, img.step,
+                            QImage::Format_RGB888);
+        QLabel label;
+        label.setPixmap(QPixmap::fromImage(dialogImg));
 
 
-    // Create a QPushButton and set its text
-    QPushButton button("Restore Image Properties");
-    QObject::connect(&button, &QPushButton::released, this, [=](){ 
-        std::string pathStr = this->gallery->getPathname();
-        //std::string fileToRestore = pathStr + caption.toStdString();
-        std::string fileToRestore = this->gallery->getGalleryDisplayFname(position);
-        restoreSettings(fileToRestore); 
-        dialog.accept();
-    });
+        // Create a QPushButton and set its text
+        QPushButton button("Restore Image Properties");
+        QObject::connect(&button, &QPushButton::released, this, [=](){ 
+            std::string pathStr = this->gallery->getPathname();
+            std::string fileToRestore = this->gallery->getGalleryDisplayFname(position);
+            restoreSettings(fileToRestore); 
+            dialog.accept();
+        });
 
-    // Create a QHBoxLayout and add the label to it
-    QVBoxLayout layout;
-    layout.addWidget(&label);
-    layout.addWidget(&button);
+        // Create a QHBoxLayout and add the label to it
+        QVBoxLayout layout;
+        layout.addWidget(&label);
+        layout.addWidget(&button);
 
-    // Add the QHBoxLayout to the dialog's layout
-    dialog.setLayout(&layout);
+        // Add the QHBoxLayout to the dialog's layout
+        dialog.setLayout(&layout);
 
-    dialog.exec();
+        dialog.exec();
     }
 }
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -159,12 +159,10 @@ Gui::Gui(QMainWindow *win, Ui_GUI *ui_win, Gallery *galleryIn, std::vector<image
         QString enteredText = ui->updateNameBox->toPlainText();
         std::string enteredTextStr = enteredText.toStdString();
         if (enteredTextStr == ""){
-            std::cout<<"switching"<<std::endl;
+            //std::cout<<"switching"<<std::endl;
             enteredTextStr = " ";
-            //ui->updateNameBox->setText(emptyQStr);
         }
         this->cam->setNote(enteredTextStr);
-        //textEditController(enteredTextStr, false);
     });
     // testing restore settings
     QObject::connect(ui->restoreSettingsButton, &QPushButton::released, this, [&](){ restoreSettings(""); });
@@ -268,7 +266,7 @@ void Gui::captureNextFrame()
 
 
 /**
-* Restores image processing settings from existing capture metadata
+* Restores image processing settings from existing capture metadata by passing to every image processor block through callback
 * @param fname filename for image to restore metadata from
 **/
 void Gui::restoreSettings(std::string fname)
@@ -278,11 +276,6 @@ void Gui::restoreSettings(std::string fname)
     metadata = this->gallery->getMetadata(fname);
 
 
-    ////debug
-    //std::string erosion = metadata["erosion"];
-    //std::cout<<"erosion::" + erosion<<std::endl;
-    
-
     //pass retrieved metadata through callbacks to each image proc block
     for (auto block : blocks){
         block->updateSettings(metadata);
@@ -290,9 +283,9 @@ void Gui::restoreSettings(std::string fname)
     this->updateSettings(metadata);//updates gui sliders
 }
 
-//resets gui sliders and checkboxes to match new settings
 /**
 * Restores GUI sliders and checkboxes to match the restored image processor settings.
+* @param metadata restored from saved capture in gallery directory.
 **/
 void Gui::updateSettings(std::map<std::string, std::string> metadata){
     //std::cout<<"in gui update settings"<<std::endl;
@@ -308,7 +301,6 @@ void Gui::updateSettings(std::map<std::string, std::string> metadata){
         };
 
 
-        //std::cout<<value<<std::endl;
 
         if (value == ""){
             std::cerr<<"check paramLabel is defined in derived image procesor class"<<std::endl;
@@ -323,6 +315,7 @@ void Gui::updateSettings(std::map<std::string, std::string> metadata){
         }
 
         //janky but not sure how else to make these connections
+        //------------------------------- iterate through metadata to restore GUI state-------------------
         if(label == "edgeThreshold"){
             try{
                 ui->edgeEnhancementSlider->setValue(std::stoi(value));
@@ -334,7 +327,6 @@ void Gui::updateSettings(std::map<std::string, std::string> metadata){
                 }
             }
         }
-                //janky but not sure how else to make these connections
         else if(label == "contrastThreshold"){
             try{
                 ui->contrastEnhancementSlider->setValue(std::stoi(value));
@@ -376,7 +368,10 @@ void Gui::updateSettings(std::map<std::string, std::string> metadata){
     
 }
 
-
+/**
+* Updates gallery previews with a new four images with labels
+* @param directionIsNext if true, moves the gallery view forward to more recent captures, otherwise back to an earlier 4 captures
+**/
 void Gui::updateGalleryView(bool directionIsNext){
     std::list<std::pair<std::string, cv::Mat>> loaded = this->gallery->getCaptures(directionIsNext);
     std::vector<std::string> keys;
@@ -386,10 +381,6 @@ void Gui::updateGalleryView(bool directionIsNext){
         keys.push_back(it->first);
         mats.push_back(it->second);
     }
-    // for (std::list<std::string, cv::Mat>::iterator it = loaded.begin(); it != loaded.end(); ++it) {
-    //     keys.push_back(it->first);
-    //     std::cout<<it->first<<std::endl;
-    // } 
 
 
     cv::Mat img;
@@ -461,31 +452,20 @@ void Gui::updateGalleryView(bool directionIsNext){
         ui->galleryPos4->clear();
         ui->namePos4->clear();
     }
+
+    //required for restoring settings from selected capture
     galleryStrs.clear();
     galleryStrs = {str1, str2, str3, str4};
     galleryQImages.clear();
-    galleryQImages={gallery1, gallery2, gallery3, gallery4};
+    galleryQImages={gallery1, gallery2, gallery3, gallery4}; 
 
 }
 
 
-//  void Gui::textEditController(std::string enteredTextStr, bool pressed){
-
-//     myString = enteredTextStr;
-//     if (!myString.empty()){
-//         std::cout<<"Entered String: "<<enteredTextStr<<std::endl;
-//         if( pressed == true){
-//             this->gallery->updateImgName(myString);
-//             bool pressed =false;F
-//         }
-//     }
-//     else{
-//         QString empty = " ";
-//         ui->updateNameBox->setText(empty);
-//         this
-//     }
-// }
-
+/**
+* Displays a popup window showing a full-sized capture with a button option to restore settings from that capture.
+* @param position position within the four spaced as 0, 1 on top row and 2, 3 on the bottom.
+**/
 //function that see's that the button is pressed, return true, make batch index go to the end and show now image, 
 void Gui::showDialog(int position) {
     dialog.accept();

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -145,7 +145,7 @@ Gui::Gui(QMainWindow *win, Ui_GUI *ui_win, Gallery *galleryIn, std::vector<image
 
     ////do a capture
     QObject::connect(ui->captureButton, &QPushButton::released, this, &Gui::captureNextFrame); //&Gui::captureNextFrame
-    QObject::connect(ui->captureButton, &QPushButton::released, this, [&](){textEditController(myString, true);});
+    //QObject::connect(ui->captureButton, &QPushButton::released, this, [&](){textEditController(myString, true);});
 
     QObject::connect(ui->FlatFieldButton, &QPushButton::released, this, &Gui::setUpdateFlatField);
 
@@ -154,9 +154,15 @@ Gui::Gui(QMainWindow *win, Ui_GUI *ui_win, Gallery *galleryIn, std::vector<image
 
     // toggle edge
     // QObject::connect(ui->captureButton, &QPushButton::released, this, [&](){blocks[2]->toggleEnable();});
+    ui->updateNameBox->setText(" ");
     QObject::connect(ui->updateNameBox, &QTextEdit::textChanged, this, [&](){
         QString enteredText = ui->updateNameBox->toPlainText();
         std::string enteredTextStr = enteredText.toStdString();
+        if (enteredTextStr == ""){
+            std::cout<<"switching"<<std::endl;
+            enteredTextStr = " ";
+            //ui->updateNameBox->setText(emptyQStr);
+        }
         this->cam->setNote(enteredTextStr);
         //textEditController(enteredTextStr, false);
     });
@@ -463,19 +469,22 @@ void Gui::updateGalleryView(bool directionIsNext){
 }
 
 
- void Gui::textEditController(std::string enteredTextStr, bool pressed){
+//  void Gui::textEditController(std::string enteredTextStr, bool pressed){
 
-    myString = enteredTextStr;
-    if (!myString.empty()){
-    std::cout<<"Entered String: "<<enteredTextStr<<std::endl;
-    if( pressed == true){
-        this->gallery->updateImgName(myString);
-        bool pressed =false;
-    }
-    else{}
-    }
-    else{}
-}
+//     myString = enteredTextStr;
+//     if (!myString.empty()){
+//         std::cout<<"Entered String: "<<enteredTextStr<<std::endl;
+//         if( pressed == true){
+//             this->gallery->updateImgName(myString);
+//             bool pressed =false;F
+//         }
+//     }
+//     else{
+//         QString empty = " ";
+//         ui->updateNameBox->setText(empty);
+//         this
+//     }
+// }
 
 //function that see's that the button is pressed, return true, make batch index go to the end and show now image, 
 void Gui::showDialog(int position) {

--- a/src/gui.h
+++ b/src/gui.h
@@ -58,6 +58,7 @@ private:
     //std::string textEditController(std::string enteredTextStr){return myString;};
     std::vector<QString> galleryStrs;  
     std::vector<cv::Mat> mats;
+    std::vector<std::string> keys;
     std::vector<QImage> galleryQImages;  
     QString str1;
     QString str2;


### PR DESCRIPTION
Fixes #78, cleans up gui.cpp and gallery.cpp.

Removes exposure restore as this was bugged and there is insufficient time to fix. Still included in metadata to allow researcher to read exposure value. 